### PR TITLE
Update README.md | Typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ const velocityLayer = L.velocityLayer({
 	// OPTIONAL
 	particleAge: 64,
 	particleMultiplier: 0.0033,
-	particleLineWidth: 1,
+	particlelineWidth: 1,
 	frameRate: 15,
 	minVelocity: 0,
 	maxVelocity: 10,


### PR DESCRIPTION
windy.ts is expecting 'particlelineWidth' as an optional parameter. The example provided simply capitalizes the 'L' which will obviously default this option to 1 and confuse a simple dev like myself. 

Side note: This project is phenomenal!